### PR TITLE
feat: Implement AI Trader Sentiment API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,97 @@
-# ai-trader-sentiment
+# AI Trader Sentiment API
+
+## Description
+
+This project provides a simple Flask-based API that performs sentiment analysis on recent news headlines for a given stock symbol. It fetches news using the NewsAPI and analyzes sentiment using the FinBERT model fine-tuned for financial text.
+
+## Setup
+
+1.  **Clone the repository:**
+    ```bash
+    git clone <repository_url> # Replace <repository_url> with the actual URL
+    cd ai-trader-sentiment
+    ```
+
+2.  **Create and activate a Python virtual environment:**
+    *   On macOS/Linux:
+        ```bash
+        python3 -m venv venv
+        source venv/bin/activate
+        ```
+    *   On Windows:
+        ```bash
+        python -m venv venv
+        .\venv\Scripts\activate
+        ```
+
+3.  **Install dependencies:**
+    ```bash
+    pip install -r requirements.txt
+    ```
+    *Note: The first time you run the application, the FinBERT model (~400MB) will be downloaded.*
+
+## Configuration
+
+1.  **Get a NewsAPI Key:**
+    You need an API key from NewsAPI to fetch news headlines. Register for a free key at [https://newsapi.org/](https://newsapi.org/).
+
+2.  **Update the API Key:**
+    Open the file `utils/news_fetcher.py` and replace the placeholder string `'YOUR_NEWSAPI_KEY'` with your actual NewsAPI key:
+    ```python
+    # Replace with your actual NewsAPI key
+    NEWS_API_KEY = 'YOUR_NEWSAPI_KEY' 
+    ```
+
+## Running the Application
+
+1.  **Start the Flask server:**
+    ```bash
+    python app.py
+    ```
+    Alternatively, you can use the Flask CLI (if Flask is installed globally or the venv is active):
+    ```bash
+    flask run --port=5001 # Specify port if needed
+    ```
+
+2.  **Accessing the API:**
+    The server will start, typically on `http://localhost:5001` or `http://0.0.0.0:5001`. The default port is 5001. You can specify a different port by setting the `PORT` environment variable before running the app:
+    ```bash
+    export PORT=8080 # macOS/Linux
+    set PORT=8080   # Windows
+    python app.py
+    ```
+
+## API Endpoint
+
+### Get Sentiment by Symbol
+
+*   **Endpoint:** `GET /sentiment/<symbol>`
+*   **Description:** Retrieves the overall sentiment (positive, negative, or neutral) based on recent news headlines for the specified stock symbol.
+*   **`<symbol>`:** The stock ticker symbol (e.g., AAPL, GOOGL, TSLA).
+
+*   **Example Request:**
+    ```bash
+    curl http://localhost:5001/sentiment/AAPL
+    ```
+
+*   **Example Success Response (200 OK):**
+    ```json
+    {
+      "symbol": "AAPL",
+      "sentiment_score": "neutral" 
+    }
+    ```
+    *(Note: The actual sentiment score will vary based on current news.)*
+
+*   **Example Error Response (404 Not Found - No News):**
+    ```json
+    {
+      "error": "No news found"
+    }
+    ```
+*   **Example Error Response (503 Service Unavailable - Model Issue):**
+    ```json
+    {
+      "error": "Sentiment analysis unavailable"
+    }
+    ```

--- a/app.py
+++ b/app.py
@@ -1,0 +1,32 @@
+import os
+from flask import Flask, jsonify
+from sentiment.sentiment_analysis import analyze_sentiment
+
+app = Flask(__name__)
+
+@app.route("/sentiment/<symbol>", methods=["GET"])
+def sentiment(symbol):
+    """
+    API endpoint to get the sentiment analysis for a given stock symbol.
+    """
+    # Convert symbol to uppercase for consistency, although news API might handle case
+    symbol_upper = symbol.upper() 
+    sentiment_score = analyze_sentiment(symbol_upper)
+    
+    # Basic validation/error handling based on analyze_sentiment output
+    if sentiment_score in ["No news found", "Sentiment analysis unavailable", "Error during analysis"]:
+        # Return an appropriate error response
+        # Using 404 for 'No news found', 503 for unavailable, 500 for analysis error
+        status_code = 404 if sentiment_score == "No news found" else (503 if sentiment_score == "Sentiment analysis unavailable" else 500)
+        return jsonify({"error": sentiment_score}), status_code
+
+    return jsonify({
+        "symbol": symbol_upper,
+        "sentiment_score": sentiment_score
+    })
+
+if __name__ == "__main__":
+    # Get the port from the environment variable "PORT", defaulting to 5001.
+    # Use host='0.0.0.0' to make it accessible externally if needed (e.g., in Docker)
+    port = int(os.getenv("PORT", 5001))
+    app.run(debug=True, host='0.0.0.0', port=port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+transformers
+yfinance
+requests

--- a/sentiment/.placeholder
+++ b/sentiment/.placeholder
@@ -1,0 +1,1 @@
+# This is a placeholder file to create the sentiment directory.

--- a/sentiment/sentiment_analysis.py
+++ b/sentiment/sentiment_analysis.py
@@ -1,0 +1,73 @@
+from transformers import BertTokenizer, BertForSequenceClassification, pipeline
+from utils.news_fetcher import fetch_news
+import torch # Import torch to potentially manage device placement if needed
+
+# Load FinBERT tokenizer and model
+model_name = "yiyanghkust/finbert-tone"
+try:
+    tokenizer = BertTokenizer.from_pretrained(model_name)
+    # Explicitly load the model for sequence classification
+    model = BertForSequenceClassification.from_pretrained(model_name) 
+    # Create sentiment analysis pipeline
+    # Specify task="text-classification" for clarity, though it's often inferred
+    # device=0 for GPU if available, -1 for CPU
+    sentiment_pipeline = pipeline("text-classification", model=model, tokenizer=tokenizer, device=-1) 
+except Exception as e:
+    print(f"Error loading model or tokenizer: {e}")
+    # Provide a fallback or raise an error if the model is essential
+    sentiment_pipeline = None 
+
+def analyze_sentiment(symbol):
+    """
+    Analyzes the sentiment of news headlines for a given stock symbol.
+
+    Args:
+        symbol (str): The stock symbol (e.g., 'AAPL').
+
+    Returns:
+        str: The overall sentiment score ('positive', 'negative', 'neutral'), 
+             or 'No news found' if no headlines are available.
+             Returns 'Sentiment analysis unavailable' if the pipeline failed to load.
+    """
+    if sentiment_pipeline is None:
+        return "Sentiment analysis unavailable"
+        
+    headlines = fetch_news(symbol)
+
+    if not headlines:
+        return "No news found"
+
+    sentiments = []
+    try:
+        # Process headlines in batches if necessary, but for 10 it's likely fine
+        results = sentiment_pipeline(headlines) 
+        # Extract just the labels
+        sentiments = [result['label'] for result in results] 
+    except Exception as e:
+        print(f"Error during sentiment analysis for {symbol}: {e}")
+        return "Error during analysis" # Or handle more gracefully
+
+    # Determine overall sentiment score
+    positive_count = sentiments.count('POSITIVE')
+    negative_count = sentiments.count('NEGATIVE')
+    # neutral_count = sentiments.count('NEUTRAL') # Not strictly needed for this logic
+
+    total_headlines = len(headlines)
+    sentiment_score = "neutral" # Default sentiment
+
+    if positive_count > total_headlines / 2:
+        sentiment_score = "positive"
+    elif negative_count > total_headlines / 2:
+        sentiment_score = "negative"
+
+    return sentiment_score
+
+if __name__ == '__main__':
+    # Example usage (replace 'AAPL' with a symbol you want to test)
+    sample_symbol = 'TSLA' 
+    overall_sentiment = analyze_sentiment(sample_symbol)
+    print(f"Overall sentiment for {sample_symbol}: {overall_sentiment}")
+
+    sample_symbol_no_news = 'NONEXISTENTSTOCKXYZ'
+    overall_sentiment_no_news = analyze_sentiment(sample_symbol_no_news)
+    print(f"Overall sentiment for {sample_symbol_no_news}: {overall_sentiment_no_news}")

--- a/utils/.placeholder
+++ b/utils/.placeholder
@@ -1,0 +1,1 @@
+# This is a placeholder file to create the utils directory.

--- a/utils/news_fetcher.py
+++ b/utils/news_fetcher.py
@@ -1,0 +1,47 @@
+import requests
+
+# Replace with your actual NewsAPI key
+NEWS_API_KEY = 'YOUR_NEWSAPI_KEY' 
+BASE_URL = 'https://newsapi.org/v2/everything'
+
+def fetch_news(symbol):
+    """
+    Fetches news headlines for a given stock symbol from NewsAPI.
+
+    Args:
+        symbol (str): The stock symbol (e.g., 'AAPL').
+
+    Returns:
+        list[str]: A list of news headlines, or an empty list if an error occurs.
+    """
+    params = {
+        'q': symbol,
+        'apiKey': NEWS_API_KEY,
+        'sortBy': 'publishedAt', # Fetch most recent news
+        'pageSize': 10 # Limit the number of articles
+    }
+    try:
+        response = requests.get(BASE_URL, params=params)
+        response.raise_for_status() # Raise an exception for bad status codes (4xx or 5xx)
+        data = response.json()
+        
+        # Extract headlines
+        headlines = [article['title'] for article in data.get('articles', []) if article.get('title')]
+        return headlines
+    except requests.exceptions.RequestException as e:
+        print(f"Error fetching news for {symbol}: {e}")
+        return []
+    except Exception as e:
+        print(f"An unexpected error occurred: {e}")
+        return []
+
+if __name__ == '__main__':
+    # Example usage (replace 'AAPL' with a symbol you want to test)
+    sample_symbol = 'AAPL' 
+    headlines = fetch_news(sample_symbol)
+    if headlines:
+        print(f"Headlines for {sample_symbol}:")
+        for i, headline in enumerate(headlines):
+            print(f"{i+1}. {headline}")
+    else:
+        print(f"Could not fetch headlines for {sample_symbol}.")


### PR DESCRIPTION
This commit introduces a Flask API for analyzing the sentiment of news articles related to a given stock or crypto symbol.

Features:
- Added a `/sentiment/<symbol>` GET endpoint.
- Fetches news headlines for the symbol using the NewsAPI.
- Analyzes the sentiment of headlines using the FinBERT model ('yiyanghkust/finbert-tone').
- Returns an overall sentiment score (positive, neutral, negative) based on the majority sentiment.
- Includes project structure (`app.py`, `sentiment/`, `utils/`), dependencies (`requirements.txt`), and usage instructions (`README.md`).

Note: Requires a NewsAPI key to be configured in `utils/news_fetcher.py`.