### PR TITLE
refactor: Read NewsAPI key from environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,12 +35,32 @@ This project provides a simple Flask-based API that performs sentiment analysis 
 1.  **Get a NewsAPI Key:**
     You need an API key from NewsAPI to fetch news headlines. Register for a free key at [https://newsapi.org/](https://newsapi.org/).
 
-2.  **Update the API Key:**
-    Open the file `utils/news_fetcher.py` and replace the placeholder string `'YOUR_NEWSAPI_KEY'` with your actual NewsAPI key:
-    ```python
-    # Replace with your actual NewsAPI key
-    NEWS_API_KEY = 'YOUR_NEWSAPI_KEY' 
-    ```
+2.  **Set the Environment Variable:**
+    The application reads the NewsAPI key from the `NEWS_API_KEY` environment variable. You must set this variable before running the application.
+
+    *   **In your terminal (macOS/Linux):**
+        ```bash
+        export NEWS_API_KEY='your_actual_key' 
+        python app.py 
+        ```
+        *(Replace `your_actual_key` with your real key)*
+
+    *   **In your terminal (Windows Command Prompt):**
+        ```bash
+        set NEWS_API_KEY=your_actual_key
+        python app.py
+        ```
+        *(Replace `your_actual_key` with your real key)*
+
+    *   **In your terminal (Windows PowerShell):**
+        ```bash
+        $env:NEWS_API_KEY='your_actual_key'
+        python app.py
+        ```
+        *(Replace `your_actual_key` with your real key)*
+
+    *   **In Deployment Environments:**
+        If deploying this application (e.g., to a cloud platform, GitHub Actions, Codespaces), configure the `NEWS_API_KEY` as an environment variable or secret according to the platform's documentation.
 
 ## Running the Application
 

--- a/utils/news_fetcher.py
+++ b/utils/news_fetcher.py
@@ -1,7 +1,8 @@
 import requests
+import os # Import os module
 
-# Replace with your actual NewsAPI key
-NEWS_API_KEY = 'YOUR_NEWSAPI_KEY' 
+# Get API key from environment variable
+NEWS_API_KEY = os.environ.get('NEWS_API_KEY') 
 BASE_URL = 'https://newsapi.org/v2/everything'
 
 def fetch_news(symbol):
@@ -13,7 +14,14 @@ def fetch_news(symbol):
 
     Returns:
         list[str]: A list of news headlines, or an empty list if an error occurs.
+        
+    Raises:
+        ValueError: If the NEWS_API_KEY environment variable is not set.
     """
+    # Check if the API key is configured
+    if not NEWS_API_KEY:
+        raise ValueError("NEWS_API_KEY environment variable not set. Please configure it.")
+
     params = {
         'q': symbol,
         'apiKey': NEWS_API_KEY,
@@ -37,9 +45,27 @@ def fetch_news(symbol):
 
 if __name__ == '__main__':
     # Example usage (replace 'AAPL' with a symbol you want to test)
-    sample_symbol = 'AAPL' 
-    headlines = fetch_news(sample_symbol)
-    if headlines:
+    # Note: This example will now raise ValueError if NEWS_API_KEY is not set
+    try:
+        sample_symbol = 'AAPL' 
+        headlines = fetch_news(sample_symbol)
+        if headlines:
+            print(f"Headlines for {sample_symbol}:")
+            for i, headline in enumerate(headlines):
+                print(f"{i+1}. {headline}")
+        else:
+            # The function now raises ValueError for missing key, 
+            # so this 'else' might indicate other issues like network errors 
+            # or no articles found by the API.
+            print(f"Could not fetch headlines for {sample_symbol} (or no headlines found).")
+    except ValueError as e:
+        print(f"Configuration Error: {e}")
+    except requests.exceptions.RequestException as e:
+        # Catch potential request errors specifically in the example block
+        print(f"Error during example news fetch: {e}")
+    except Exception as e:
+        print(f"An unexpected error occurred during example execution: {e}")
+
         print(f"Headlines for {sample_symbol}:")
         for i, headline in enumerate(headlines):
             print(f"{i+1}. {headline}")


### PR DESCRIPTION
Modified the application to read the NewsAPI key from the `NEWS_API_KEY` environment variable instead of a hardcoded placeholder.

- Updated `utils/news_fetcher.py` to use `os.environ.get()`.
- Added error handling in `fetch_news` to raise a ValueError if the environment variable is not set.
- Updated `README.md` configuration instructions to reflect the use of the environment variable.

This improves security by removing the need to store secrets directly in the code.